### PR TITLE
C extend v5 - bump to 68k due to __attribute__((always_inline))

### DIFF
--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -30,14 +30,16 @@ Inspired by:
 - Use manual unroll for small sizes
 - Small changes in code can have huge impact due to -Ofast of -O3 optimizations
 - Using vector can greatly speed thing up, because of the sse/avx extensions
+- __attribute__((always_inline)) can force inlining a function
+- doing while (index<range_stop) and then if (index==range_stop) is faster than while (index<=range_stop)
 
 Sources:
-https://www.agner.org/optimize/
-https://stackoverflow.com/questions/21681300/diferences-between-pragmas-simd-and-ivdep-vector-always
-https://stackoverflow.com/questions/25248766/emulating-shifts-on-32-bytes-with-avx
-https://stackoverflow.com/questions/3005564/gcc-recommendations-and-options-for-fastest-code
-https://github.com/simd-everywhere/simde
-https://www.cprogramming.com/tips/tip/common-optimization-tips
+- https://www.agner.org/optimize/
+- https://stackoverflow.com/questions/21681300/diferences-between-pragmas-simd-and-ivdep-vector-always
+- https://stackoverflow.com/questions/25248766/emulating-shifts-on-32-bytes-with-avx
+- https://stackoverflow.com/questions/3005564/gcc-recommendations-and-options-for-fastest-code
+- https://github.com/simd-everywhere/simde
+- https://www.cprogramming.com/tips/tip/common-optimization-tips
 
 ## Choice of Dockerfile
 This solution uses Ubuntu 20.04 as the base image.


### PR DESCRIPTION
## Description
[bump to 68k due to __attribute__((always_inline))](https://github.com/rogiervandam/Primes/commit/6fd56a5d11b5778884b2385a8013457bdb7cb0fb)

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [xI placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
